### PR TITLE
feat: add normalized risk insight engine

### DIFF
--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TokenProfile } from "../shared/types";
+
+const fetchTokenById = vi.fn();
+const fetchTokenByContract = vi.fn();
+const fetchSimplePrices = vi.fn();
+const fetchFundamentals = vi.fn();
+const fetchPrices = vi.fn();
+const formatCoinId = vi.fn(() => "coingecko:ethereum");
+const clearExpired = vi.fn();
+const getRiskAssessment = vi.fn();
+
+vi.mock("../shared/api/coingecko", () => ({
+  fetchTokenById,
+  fetchTokenByContract,
+  fetchSimplePrices,
+}));
+
+vi.mock("../shared/api/defi-llama", () => ({
+  fetchFundamentals,
+  fetchPrices,
+  formatCoinId,
+}));
+
+vi.mock("../shared/cache", () => ({
+  clearExpired,
+}));
+
+vi.mock("../shared/risk/engine", () => ({
+  InsightEngine: class {
+    register(): void {}
+    getRiskAssessment = getRiskAssessment;
+  },
+}));
+
+vi.mock("../shared/risk/providers/rugcheck", () => ({
+  RugCheckProvider: class {},
+}));
+
+vi.mock("../shared/risk/providers/internal", () => ({
+  InternalHeuristicsProvider: class {},
+}));
+
+vi.stubGlobal("chrome", {
+  runtime: {
+    onMessage: {
+      addListener: vi.fn(),
+    },
+  },
+  alarms: {
+    create: vi.fn(),
+    onAlarm: {
+      addListener: vi.fn(),
+    },
+  },
+});
+
+describe("background handleMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns profile and risk assessment for RESOLVE_TOKEN", async () => {
+    const profile: TokenProfile = {
+      id: "ethereum",
+      coingeckoId: "ethereum",
+      name: "Ethereum",
+      symbol: "ETH",
+      chains: ["ethereum"],
+      price: 1000,
+      priceChange24h: 0,
+      ath: 4000,
+      supply: {
+        type: "inflationary",
+        circulatingSupply: 100,
+        totalSupply: 100,
+        circulatingPercent: 100,
+        marketCap: 1000000,
+        fdv: 1000000,
+        fdvToMcapRatio: 1,
+        hasBurnMechanism: false,
+      },
+      lastUpdated: Date.now(),
+    };
+
+    fetchTokenById.mockResolvedValue(profile);
+    fetchFundamentals.mockResolvedValue({ tvlUsd: 10_000_000, tvlTrend: "growing" });
+    fetchPrices.mockResolvedValue({ "coingecko:ethereum": { price: 1100 } });
+    getRiskAssessment.mockResolvedValue({
+      riskLevel: "low",
+      score: 10,
+      verdict: "No major concerns detected",
+      insights: [],
+      providers: ["Internal Heuristics"],
+    });
+
+    const { handleMessage } = await import("./index");
+    const result = await handleMessage({
+      type: "RESOLVE_TOKEN",
+      payload: { id: "ethereum" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        profile: expect.objectContaining({ id: "ethereum", price: 1100 }),
+        risk: expect.objectContaining({ riskLevel: "low" }),
+      },
+    });
+  });
+});

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,6 +9,10 @@ import {
   formatCoinId,
 } from "../shared/api/defi-llama";
 import { clearExpired } from "../shared/cache";
+import { InsightEngine } from "../shared/risk/engine";
+import { InternalHeuristicsProvider } from "../shared/risk/providers/internal";
+import { RugCheckProvider } from "../shared/risk/providers/rugcheck";
+import type { RiskAssessment } from "../shared/risk/types";
 import type {
   Chain,
   Message,
@@ -69,7 +73,7 @@ chrome.runtime.onMessage.addListener(
   },
 );
 
-async function handleMessage(message: Message): Promise<MessageResponse> {
+export async function handleMessage(message: Message): Promise<MessageResponse> {
   switch (message.type) {
     case "RESOLVE_TOKEN":
       return isResolveTokenPayload(message.payload)
@@ -100,7 +104,7 @@ async function handleMessage(message: Message): Promise<MessageResponse> {
 
 async function resolveToken(payload: {
   id: string;
-}): Promise<MessageResponse<TokenProfile>> {
+}): Promise<MessageResponse<{ profile: TokenProfile; risk: RiskAssessment }>> {
   const profile = await fetchTokenById(payload.id);
 
   // Enrich with DeFiLlama fundamentals (TVL, revenue)
@@ -117,13 +121,20 @@ async function resolveToken(payload: {
     profile.price = dlPrice.price;
   }
 
-  return { success: true, data: profile };
+  const risk = await createInsightEngine().getRiskAssessment({
+    type: "token",
+    identifier: profile.id,
+    chain: profile.chains[0],
+    tokenProfile: profile,
+  });
+
+  return { success: true, data: { profile, risk } };
 }
 
 async function resolveAddress(payload: {
   address: string;
   chain: Chain;
-}): Promise<MessageResponse<TokenProfile>> {
+}): Promise<MessageResponse<{ profile: TokenProfile; risk: RiskAssessment }>> {
   // Try CoinGecko contract lookup first (gives full profile)
   const profile = await fetchTokenByContract(payload.chain, payload.address);
   if (!profile) {
@@ -136,7 +147,14 @@ async function resolveAddress(payload: {
     profile.fundamentals = fundamentals;
   }
 
-  return { success: true, data: profile };
+  const risk = await createInsightEngine().getRiskAssessment({
+    type: "token",
+    identifier: payload.address,
+    chain: payload.chain,
+    tokenProfile: profile,
+  });
+
+  return { success: true, data: { profile, risk } };
 }
 
 async function searchToken(payload: {
@@ -150,6 +168,16 @@ async function searchToken(payload: {
     return { success: true, data: profile };
   }
   return { success: false, error: "Token not found" };
+}
+
+/**
+ * Builds the current set of risk providers for each background request.
+ */
+function createInsightEngine(): InsightEngine {
+  const engine = new InsightEngine();
+  engine.register(new RugCheckProvider());
+  engine.register(new InternalHeuristicsProvider());
+  return engine;
 }
 
 // ---------- Scheduled cache cleanup ----------

--- a/src/shared/risk/engine.test.ts
+++ b/src/shared/risk/engine.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { InsightEngine } from "./engine";
+import type { RiskEntity, RiskProvider } from "./types";
+
+function createEntity(overrides: Partial<RiskEntity> = {}): RiskEntity {
+  return {
+    type: "token",
+    identifier: "ethereum",
+    ...overrides,
+  };
+}
+
+describe("InsightEngine", () => {
+  it("runs matching providers and aggregates a medium-risk assessment", async () => {
+    const engine = new InsightEngine();
+    const entity = createEntity();
+
+    const provider: RiskProvider = {
+      id: "internal",
+      name: "Internal",
+      canHandle: () => true,
+      getInsights: async () => [
+        {
+          signal: "High dilution risk",
+          severity: "warning",
+          detail: "FDV is far above market cap",
+          provider: "Internal",
+          category: "supply",
+        },
+      ],
+    };
+
+    engine.register(provider);
+
+    const assessment = await engine.getRiskAssessment(entity);
+
+    expect(assessment.riskLevel).toBe("medium");
+    expect(assessment.score).toBeGreaterThan(0);
+    expect(assessment.providers).toEqual(["Internal"]);
+    expect(assessment.insights).toHaveLength(1);
+  });
+
+  it("deduplicates overlapping insights from different providers", async () => {
+    const engine = new InsightEngine();
+    const entity = createEntity();
+
+    engine.register({
+      id: "one",
+      name: "Provider One",
+      canHandle: () => true,
+      getInsights: async () => [
+        {
+          signal: "Low liquidity",
+          severity: "warning",
+          detail: "Liquidity is below threshold",
+          provider: "Provider One",
+          category: "liquidity",
+        },
+      ],
+    });
+    engine.register({
+      id: "two",
+      name: "Provider Two",
+      canHandle: () => true,
+      getInsights: async () => [
+        {
+          signal: "Low liquidity",
+          severity: "warning",
+          detail: "Liquidity is below threshold",
+          provider: "Provider Two",
+          category: "liquidity",
+        },
+      ],
+    });
+
+    const assessment = await engine.getRiskAssessment(entity);
+
+    expect(assessment.insights).toHaveLength(1);
+    expect(assessment.providers).toEqual(["Provider One", "Provider Two"]);
+  });
+
+  it("isolates provider failures and still returns results from healthy providers", async () => {
+    const engine = new InsightEngine();
+    const entity = createEntity();
+
+    engine.register({
+      id: "broken",
+      name: "Broken Provider",
+      canHandle: () => true,
+      getInsights: async () => {
+        throw new Error("provider failed");
+      },
+    });
+    engine.register({
+      id: "healthy",
+      name: "Healthy Provider",
+      canHandle: () => true,
+      getInsights: async () => [
+        {
+          signal: "Mint authority enabled",
+          severity: "critical",
+          detail: "Token can mint more supply",
+          provider: "Healthy Provider",
+          category: "contract",
+        },
+      ],
+    });
+
+    const assessment = await engine.getRiskAssessment(entity);
+
+    expect(assessment.riskLevel).toBe("high");
+    expect(assessment.insights).toHaveLength(1);
+    expect(assessment.providers).toEqual(["Healthy Provider"]);
+  });
+});

--- a/src/shared/risk/engine.ts
+++ b/src/shared/risk/engine.ts
@@ -1,0 +1,114 @@
+import type { RiskAssessment, RiskEntity, RiskInsight, RiskProvider } from "./types";
+
+const SEVERITY_SCORE: Record<RiskInsight["severity"], number> = {
+  info: 10,
+  warning: 35,
+  critical: 70,
+};
+
+/**
+ * Runs matching risk providers, merges their signals, and computes a single
+ * assessment that the rest of the extension can consume.
+ */
+export class InsightEngine {
+  private readonly providers: RiskProvider[] = [];
+
+  /**
+   * Registers a provider without coupling the engine to provider classes.
+   */
+  register(provider: RiskProvider): void {
+    this.providers.push(provider);
+  }
+
+  /**
+   * Returns an aggregate risk assessment while isolating provider failures.
+   */
+  async getRiskAssessment(entity: RiskEntity): Promise<RiskAssessment> {
+    const matchingProviders = this.providers.filter((provider) =>
+      provider.canHandle(entity),
+    );
+
+    const results = await Promise.all(
+      matchingProviders.map(async (provider) => {
+        try {
+          return {
+            provider: provider.name,
+            insights: await provider.getInsights(entity),
+          };
+        } catch {
+          return {
+            provider: provider.name,
+            insights: [],
+          };
+        }
+      }),
+    );
+
+    const insights = dedupeInsights(results.flatMap((result) => result.insights));
+    const providers = results
+      .filter((result) => result.insights.length > 0)
+      .map((result) => result.provider);
+    const score = computeScore(insights);
+    const riskLevel = computeRiskLevel(score);
+
+    return {
+      riskLevel,
+      score,
+      verdict: buildVerdict(riskLevel, insights),
+      insights,
+      providers,
+    };
+  }
+}
+
+function dedupeInsights(insights: RiskInsight[]): RiskInsight[] {
+  const deduped = new Map<string, RiskInsight>();
+
+  for (const insight of insights) {
+    const key = `${insight.category}:${insight.signal.toLowerCase()}`;
+    const existing = deduped.get(key);
+    if (!existing || SEVERITY_SCORE[insight.severity] > SEVERITY_SCORE[existing.severity]) {
+      deduped.set(key, insight);
+    }
+  }
+
+  return Array.from(deduped.values());
+}
+
+function computeScore(insights: RiskInsight[]): number {
+  if (insights.length === 0) return 0;
+
+  const total = insights.reduce(
+    (sum, insight) => sum + SEVERITY_SCORE[insight.severity],
+    0,
+  );
+
+  return Math.min(100, total);
+}
+
+function computeRiskLevel(score: number): RiskAssessment["riskLevel"] {
+  if (score >= 70) return "high";
+  if (score >= 25) return "medium";
+  return "low";
+}
+
+function buildVerdict(
+  riskLevel: RiskAssessment["riskLevel"],
+  insights: RiskInsight[],
+): string {
+  if (insights.length === 0) {
+    return "No major risk signals detected";
+  }
+
+  const topInsight = insights
+    .slice()
+    .sort((left, right) => SEVERITY_SCORE[right.severity] - SEVERITY_SCORE[left.severity])[0];
+
+  if (riskLevel === "high") {
+    return `High risk: ${topInsight.signal.toLowerCase()}`;
+  }
+  if (riskLevel === "medium") {
+    return `Caution: ${topInsight.signal.toLowerCase()}`;
+  }
+  return `Low risk with minor concern: ${topInsight.signal.toLowerCase()}`;
+}

--- a/src/shared/risk/providers/internal.test.ts
+++ b/src/shared/risk/providers/internal.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { InternalHeuristicsProvider } from "./internal";
+import type { RiskEntity } from "../types";
+import type { TokenProfile } from "../../types";
+
+function createProfile(overrides: Partial<TokenProfile> = {}): TokenProfile {
+  return {
+    id: "sample",
+    coingeckoId: "sample",
+    name: "Sample",
+    symbol: "SMP",
+    chains: ["ethereum"],
+    price: 1,
+    priceChange24h: 0,
+    ath: 2,
+    supply: {
+      type: "inflationary",
+      circulatingSupply: 20,
+      totalSupply: 100,
+      circulatingPercent: 20,
+      marketCap: 100000,
+      fdv: 1000000,
+      fdvToMcapRatio: 10,
+      hasBurnMechanism: false,
+    },
+    lastUpdated: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("InternalHeuristicsProvider", () => {
+  it("only handles entities that already have a token profile", () => {
+    const provider = new InternalHeuristicsProvider();
+
+    expect(
+      provider.canHandle({ type: "token", identifier: "eth", tokenProfile: createProfile() }),
+    ).toBe(true);
+    expect(provider.canHandle({ type: "token", identifier: "eth" })).toBe(false);
+  });
+
+  it("emits dilution, circulation, liquidity, and revenue insights", async () => {
+    const provider = new InternalHeuristicsProvider();
+    const entity: RiskEntity = {
+      type: "token",
+      identifier: "sample",
+      tokenProfile: createProfile({
+        fundamentals: {
+          tvlUsd: 500000,
+          tvlTrend: "shrinking",
+          revenueUsd: 100000,
+          revenueTrend: "shrinking",
+        },
+      }),
+    };
+
+    const insights = await provider.getInsights(entity);
+
+    expect(insights.map((insight) => insight.signal)).toEqual(
+      expect.arrayContaining([
+        "High dilution risk",
+        "Low circulating supply",
+        "Low liquidity",
+        "Revenue is shrinking",
+      ]),
+    );
+  });
+});

--- a/src/shared/risk/providers/internal.ts
+++ b/src/shared/risk/providers/internal.ts
@@ -1,0 +1,65 @@
+import type { RiskEntity, RiskInsight, RiskProvider } from "../types";
+
+/**
+ * Applies local heuristics to already-resolved token profiles so the extension
+ * can surface risk signals even when no chain-specific provider is available.
+ */
+export class InternalHeuristicsProvider implements RiskProvider {
+  readonly id = "internal-heuristics";
+  readonly name = "Internal Heuristics";
+
+  canHandle(entity: RiskEntity): boolean {
+    return entity.type === "token" && entity.tokenProfile !== undefined;
+  }
+
+  async getInsights(entity: RiskEntity): Promise<RiskInsight[]> {
+    const profile = entity.tokenProfile;
+    if (!profile) {
+      return [];
+    }
+
+    const insights: RiskInsight[] = [];
+
+    if (profile.supply.fdvToMcapRatio > 5) {
+      insights.push({
+        signal: "High dilution risk",
+        severity: "warning",
+        detail: "Fully diluted valuation is much higher than market cap",
+        provider: this.name,
+        category: "supply",
+      });
+    }
+
+    if (profile.supply.circulatingPercent < 30) {
+      insights.push({
+        signal: "Low circulating supply",
+        severity: "warning",
+        detail: "A small share of total supply is currently circulating",
+        provider: this.name,
+        category: "supply",
+      });
+    }
+
+    if ((profile.fundamentals?.tvlUsd ?? Number.POSITIVE_INFINITY) < 1_000_000) {
+      insights.push({
+        signal: "Low liquidity",
+        severity: "warning",
+        detail: "Protocol TVL is below the minimum liquidity threshold",
+        provider: this.name,
+        category: "liquidity",
+      });
+    }
+
+    if (profile.fundamentals?.revenueTrend === "shrinking") {
+      insights.push({
+        signal: "Revenue is shrinking",
+        severity: "warning",
+        detail: "Protocol revenue trend is currently negative",
+        provider: this.name,
+        category: "fundamentals",
+      });
+    }
+
+    return insights;
+  }
+}

--- a/src/shared/risk/providers/rugcheck.test.ts
+++ b/src/shared/risk/providers/rugcheck.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RugCheckProvider } from "./rugcheck";
+
+const { fetchTokenSummary } = vi.hoisted(() => ({
+  fetchTokenSummary: vi.fn(),
+}));
+
+vi.mock("../../api/rugcheck", () => ({
+  fetchTokenSummary,
+}));
+
+describe("RugCheckProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("only handles Solana token entities", () => {
+    const provider = new RugCheckProvider();
+
+    expect(
+      provider.canHandle({
+        type: "token",
+        identifier: "So11111111111111111111111111111111111111112",
+        chain: "solana",
+      }),
+    ).toBe(true);
+    expect(
+      provider.canHandle({
+        type: "token",
+        identifier: "0xabc",
+        chain: "ethereum",
+      }),
+    ).toBe(false);
+  });
+
+  it("maps RugCheck summary risks and LP lock warnings into insights", async () => {
+    fetchTokenSummary.mockResolvedValue({
+      mint: "So11111111111111111111111111111111111111112",
+      score: 1000,
+      normalizedScore: 80,
+      tokenProgram: "Tokenkeg",
+      tokenType: "spl",
+      lpLockedPct: 60,
+      risks: [
+        {
+          name: "Mint authority enabled",
+          level: "high",
+          description: "Token can mint more supply",
+        },
+      ],
+    });
+
+    const provider = new RugCheckProvider();
+    const insights = await provider.getInsights({
+      type: "token",
+      identifier: "So11111111111111111111111111111111111111112",
+      chain: "solana",
+    });
+
+    expect(insights.map((insight) => insight.signal)).toEqual(
+      expect.arrayContaining(["Mint authority enabled", "Low liquidity lock"]),
+    );
+    expect(insights.find((insight) => insight.signal === "Mint authority enabled")?.severity).toBe(
+      "critical",
+    );
+  });
+});

--- a/src/shared/risk/providers/rugcheck.ts
+++ b/src/shared/risk/providers/rugcheck.ts
@@ -1,0 +1,52 @@
+import { fetchTokenSummary } from "../../api/rugcheck";
+import type { RiskEntity, RiskInsight, RiskProvider, RiskSeverity } from "../types";
+
+/**
+ * Adapts RugCheck's Solana-specific token summary into normalized risk signals.
+ */
+export class RugCheckProvider implements RiskProvider {
+  readonly id = "rugcheck";
+  readonly name = "RugCheck";
+
+  canHandle(entity: RiskEntity): boolean {
+    return entity.type === "token" && entity.chain === "solana";
+  }
+
+  async getInsights(entity: RiskEntity): Promise<RiskInsight[]> {
+    const summary = await fetchTokenSummary(entity.identifier);
+    if (!summary) {
+      return [];
+    }
+
+    const insights = summary.risks.map((risk) => ({
+      signal: risk.name,
+      severity: mapSeverity(risk.level),
+      detail: risk.description ?? "RugCheck flagged this token",
+      provider: this.name,
+      category: "contract" as const,
+    }));
+
+    if (summary.lpLockedPct !== undefined && summary.lpLockedPct < 80) {
+      insights.push({
+        signal: "Low liquidity lock",
+        severity: "warning",
+        detail: `Only ${summary.lpLockedPct}% of liquidity appears locked`,
+        provider: this.name,
+        category: "liquidity",
+      });
+    }
+
+    return insights;
+  }
+}
+
+function mapSeverity(level: string): RiskSeverity {
+  const normalized = level.toLowerCase();
+  if (normalized === "high" || normalized === "critical" || normalized === "danger") {
+    return "critical";
+  }
+  if (normalized === "warn" || normalized === "warning" || normalized === "medium") {
+    return "warning";
+  }
+  return "info";
+}

--- a/src/shared/risk/types.ts
+++ b/src/shared/risk/types.ts
@@ -1,0 +1,60 @@
+import type { Chain, TokenProfile } from "../types";
+
+/**
+ * Categories used to group normalized risk signals from different providers.
+ */
+export type RiskCategory =
+  | "supply"
+  | "liquidity"
+  | "ownership"
+  | "contract"
+  | "fundamentals"
+  | "general";
+
+/**
+ * Severity scale shared across providers so the engine can aggregate them.
+ */
+export type RiskSeverity = "info" | "warning" | "critical";
+
+/**
+ * Normalized entity shape that providers can reason about without depending on
+ * message-layer payloads or provider-specific fetch logic.
+ */
+export interface RiskEntity {
+  type: "token" | "address" | "wallet";
+  identifier: string;
+  chain?: Chain;
+  tokenProfile?: TokenProfile;
+}
+
+/**
+ * Single risk signal produced by a provider after normalizing raw source data.
+ */
+export interface RiskInsight {
+  signal: string;
+  severity: RiskSeverity;
+  detail: string;
+  provider: string;
+  category: RiskCategory;
+}
+
+/**
+ * Final aggregate risk result returned by the engine for UI and messaging.
+ */
+export interface RiskAssessment {
+  riskLevel: "low" | "medium" | "high";
+  score: number;
+  verdict: string;
+  insights: RiskInsight[];
+  providers: string[];
+}
+
+/**
+ * Provider contract for any source capable of emitting normalized risk signals.
+ */
+export interface RiskProvider {
+  readonly id: string;
+  readonly name: string;
+  canHandle(entity: RiskEntity): boolean;
+  getInsights(entity: RiskEntity): Promise<RiskInsight[]>;
+}


### PR DESCRIPTION
## Summary
- add a shared risk module with normalized risk types and an InsightEngine
- implement Internal Heuristics and RugCheck providers with provider-specific tests
- wire the background resolver to return { profile, risk } using the new engine

## Testing
- npm test -- src/shared/risk/engine.test.ts src/shared/risk/providers/internal.test.ts src/shared/risk/providers/rugcheck.test.ts src/background/index.test.ts
- npm test

Closes #9