### PR TITLE
feat: add throttled SPA-aware dynamic scanner

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -22,9 +22,15 @@ try {
 
   scan();
 
-  startDynamicPageScanner((newNodes) => {
-    console.log(`[Crypto X-Ray] ${newNodes.length} new nodes detected`);
-    const highlighted = highlightDetectedTerms(newNodes);
+  startDynamicPageScanner((event) => {
+    if (event.type === "full") {
+      console.log("[Crypto X-Ray] SPA navigation detected, running full re-scan");
+      scan();
+      return;
+    }
+
+    console.log(`[Crypto X-Ray] ${event.nodes.length} new nodes detected`);
+    const highlighted = highlightDetectedTerms(event.nodes);
     console.log(`[Crypto X-Ray] Highlighted ${highlighted} new nodes`);
   });
 

--- a/src/content/text-scanner.test.ts
+++ b/src/content/text-scanner.test.ts
@@ -1,6 +1,10 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { getVisibleTextNodes, startDynamicPageScanner } from "./text-scanner";
+import {
+  getVisibleTextNodes,
+  startDynamicPageScanner,
+  type DynamicScanEvent,
+} from "./text-scanner";
 
 function createMockElement(
   tag: string,
@@ -161,38 +165,150 @@ describe("getVisibleTextNodes", () => {
 describe("startDynamicPageScanner", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.useRealTimers();
   });
 
   it("returns a cleanup function", () => {
     const callback = vi.fn();
-    const stop = startDynamicPageScanner(callback, 100);
+    const stop = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
     expect(typeof stop).toBe("function");
     stop();
   });
 
   it("does not call callback after cleanup", () => {
     const callback = vi.fn();
-    const stop = startDynamicPageScanner(callback, 100);
+    const stop = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
     stop();
 
     const text = createText("After cleanup");
     document.body.appendChild(text);
+    vi.advanceTimersByTime(150);
 
     expect(callback).not.toHaveBeenCalled();
   });
 
   it("does not start duplicate observers", () => {
     const callback = vi.fn();
-    const stop1 = startDynamicPageScanner(callback, 100);
-    const stop2 = startDynamicPageScanner(callback, 100);
+    const stop1 = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
+    const stop2 = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
 
     expect(stop1).not.toBe(stop2);
     expect(stop2()).toBeUndefined();
 
     stop1();
+  });
+
+  it("emits incremental scans for newly added visible nodes", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
+
+    document.body.appendChild(createText("Dynamic $SOL node"));
+    await Promise.resolve();
+    vi.advanceTimersByTime(100);
+
+    expect(callback).toHaveBeenCalledWith({
+      type: "incremental",
+      nodes: [expect.any(Text)],
+    });
+    const event = callback.mock.calls[0]?.[0];
+    expect(event?.type).toBe("incremental");
+    if (event?.type === "incremental") {
+      expect(event.nodes[0]?.textContent).toBe("Dynamic $SOL node");
+    }
+
+    stop();
+  });
+
+  it("deduplicates rapid mutations for the same text node", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
+    const wrapper = document.createElement("div");
+    const text = createText("Repeated $ETH node");
+    wrapper.appendChild(text);
+    document.body.appendChild(wrapper);
+    await Promise.resolve();
+
+    wrapper.removeChild(text);
+    wrapper.appendChild(text);
+    await Promise.resolve();
+    vi.advanceTimersByTime(100);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    const event = callback.mock.calls[0]?.[0];
+    expect(event?.type).toBe("incremental");
+    if (event?.type === "incremental") {
+      expect(event.nodes).toHaveLength(1);
+    }
+
+    stop();
+  });
+
+  it("skips already highlighted nodes during mutation scans", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 100, throttleMs: 100 });
+    const span = document.createElement("span");
+    span.className = "crypto-xray-highlight";
+    span.appendChild(createText("$BTC"));
+    document.body.appendChild(span);
+
+    await Promise.resolve();
+    vi.advanceTimersByTime(100);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it("throttles dynamic scans to at most one dispatch per throttle window", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 50, throttleMs: 500 });
+
+    document.body.appendChild(createText("First node"));
+    await Promise.resolve();
+    vi.advanceTimersByTime(50);
+
+    document.body.appendChild(createText("Second node"));
+    await Promise.resolve();
+    vi.advanceTimersByTime(50);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(450);
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.calls[1]?.[0]?.type).toBe("incremental");
+
+    stop();
+  });
+
+  it("requests a full re-scan when history navigation changes the URL", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 50, throttleMs: 100 });
+
+    history.pushState({}, "", "/next-page");
+    await Promise.resolve();
+    vi.advanceTimersByTime(100);
+
+    expect(callback).toHaveBeenCalledWith({ type: "full" });
+
+    stop();
+  });
+
+  it("requests a full re-scan on popstate", async () => {
+    const callback = vi.fn<[DynamicScanEvent], void>();
+    const stop = startDynamicPageScanner(callback, { debounceMs: 50, throttleMs: 100 });
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await Promise.resolve();
+    vi.advanceTimersByTime(100);
+
+    expect(callback).toHaveBeenCalledWith({ type: "full" });
+
+    stop();
   });
 });

--- a/src/content/text-scanner.ts
+++ b/src/content/text-scanner.ts
@@ -4,6 +4,14 @@
  */
 
 const IGNORED_TAGS = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "INPUT", "TEXTAREA"]);
+const HIGHLIGHT_CLASS = "crypto-xray-highlight";
+
+export interface DynamicScannerOptions {
+  debounceMs?: number;
+  throttleMs?: number;
+}
+
+export type DynamicScanEvent = { type: "full" } | { nodes: Text[]; type: "incremental" };
 
 /**
  * Checks if an element is visible on the page.
@@ -45,6 +53,14 @@ function isContentEditable(el: Element): boolean {
 }
 
 /**
+ * Checks whether a text node already lives inside one of our highlight spans.
+ * Re-scanning those nodes causes duplicate wrapping on dynamic pages.
+ */
+function isHighlightedTextNode(node: Text): boolean {
+  return node.parentElement?.classList.contains(HIGHLIGHT_CLASS) ?? false;
+}
+
+/**
  * Traverses the DOM and returns all visible text nodes with non-whitespace content.
  * Ignores script, style, noscript, input, textarea, and contenteditable elements.
  * @param root - The root node to start scanning from (defaults to document.body)
@@ -58,6 +74,7 @@ export function getVisibleTextNodes(root: Node = document.body): Text[] {
     acceptNode(node) {
       if (!node.textContent?.trim()) return NodeFilter.FILTER_REJECT;
       if (!isNodeVisible(node)) return NodeFilter.FILTER_REJECT;
+      if (node instanceof Text && isHighlightedTextNode(node)) return NodeFilter.FILTER_REJECT;
       return NodeFilter.FILTER_ACCEPT;
     },
   });
@@ -83,6 +100,7 @@ function collectVisibleTextNodes(root: Node): Text[] {
     acceptNode(node) {
       if (!node.textContent?.trim()) return NodeFilter.FILTER_REJECT;
       if (!isNodeVisible(node)) return NodeFilter.FILTER_REJECT;
+      if (node instanceof Text && isHighlightedTextNode(node)) return NodeFilter.FILTER_REJECT;
       return NodeFilter.FILTER_ACCEPT;
     },
   });
@@ -98,7 +116,155 @@ function collectVisibleTextNodes(root: Node): Text[] {
 }
 
 let observer: MutationObserver | null = null;
-let scanTimeout: ReturnType<typeof setTimeout> | null = null;
+let scheduleTimeout: ReturnType<typeof setTimeout> | null = null;
+let patchedHistory = false;
+let restorePushState: History["pushState"] | null = null;
+let restoreReplaceState: History["replaceState"] | null = null;
+let lastDispatchTime = 0;
+let pendingFullScan = false;
+let pendingNodes = new Set<Text>();
+let processedNodes = new WeakSet<Text>();
+
+function resetPendingState(): void {
+  pendingFullScan = false;
+  pendingNodes = new Set<Text>();
+}
+
+/**
+ * Emits either a full re-scan request or the currently queued incremental nodes.
+ */
+function dispatchScheduledScan(onScan: (event: DynamicScanEvent) => void): void {
+  scheduleTimeout = null;
+  lastDispatchTime = Date.now();
+
+  if (pendingFullScan) {
+    resetPendingState();
+    processedNodes = new WeakSet<Text>();
+    onScan({ type: "full" });
+    return;
+  }
+
+  const nodes = [...pendingNodes];
+  resetPendingState();
+
+  if (nodes.length === 0) {
+    return;
+  }
+
+  for (const node of nodes) {
+    processedNodes.add(node);
+  }
+
+  onScan({ type: "incremental", nodes });
+}
+
+/**
+ * Schedules a scanner callback while respecting debounce and throttle windows.
+ */
+function scheduleScan(
+  onScan: (event: DynamicScanEvent) => void,
+  debounceMs: number,
+  throttleMs: number,
+  prioritizeFullScan = false
+): void {
+  if (scheduleTimeout) {
+    clearTimeout(scheduleTimeout);
+  }
+
+  const throttleDelay = Math.max(0, throttleMs - (Date.now() - lastDispatchTime));
+  const debounceDelay = prioritizeFullScan ? 0 : debounceMs;
+  const delay = Math.max(throttleDelay, debounceDelay);
+  scheduleTimeout = setTimeout(() => dispatchScheduledScan(onScan), delay);
+}
+
+/**
+ * Adds new text nodes into the current incremental scan batch.
+ */
+function queueIncrementalNodes(
+  nodes: Text[],
+  onScan: (event: DynamicScanEvent) => void,
+  debounceMs: number,
+  throttleMs: number
+): void {
+  for (const node of nodes) {
+    if (processedNodes.has(node) || pendingNodes.has(node) || isHighlightedTextNode(node)) {
+      continue;
+    }
+
+    pendingNodes.add(node);
+  }
+
+  if (pendingNodes.size > 0) {
+    scheduleScan(onScan, debounceMs, throttleMs);
+  }
+}
+
+/**
+ * Requests a throttled full re-scan, upgrading any queued incremental work.
+ */
+function queueFullScan(
+  onScan: (event: DynamicScanEvent) => void,
+  debounceMs: number,
+  throttleMs: number
+): void {
+  pendingFullScan = true;
+  pendingNodes.clear();
+  scheduleScan(onScan, debounceMs, throttleMs, true);
+}
+
+/**
+ * Installs history listeners so SPA navigation can trigger a full re-scan.
+ */
+function patchHistory(
+  onScan: (event: DynamicScanEvent) => void,
+  debounceMs: number,
+  throttleMs: number
+): void {
+  if (patchedHistory) {
+    return;
+  }
+
+  restorePushState = history.pushState.bind(history);
+  restoreReplaceState = history.replaceState.bind(history);
+
+  history.pushState = function pushState(...args) {
+    restorePushState?.(...args);
+    queueFullScan(onScan, debounceMs, throttleMs);
+  };
+
+  history.replaceState = function replaceState(...args) {
+    restoreReplaceState?.(...args);
+    queueFullScan(onScan, debounceMs, throttleMs);
+  };
+
+  window.addEventListener("popstate", handlePopState);
+  patchedHistory = true;
+}
+
+function unpatchHistory(): void {
+  if (!patchedHistory) {
+    return;
+  }
+
+  if (restorePushState) {
+    history.pushState = restorePushState;
+  }
+
+  if (restoreReplaceState) {
+    history.replaceState = restoreReplaceState;
+  }
+
+  restorePushState = null;
+  restoreReplaceState = null;
+  window.removeEventListener("popstate", handlePopState);
+  patchedHistory = false;
+}
+
+let currentPopstateHandler: (() => void) | null = null;
+
+function handlePopState(): void {
+  currentPopstateHandler?.();
+}
 
 /**
  * Observes DOM mutations and reports newly added visible text nodes.
@@ -108,10 +274,17 @@ let scanTimeout: ReturnType<typeof setTimeout> | null = null;
  * @returns Cleanup function to stop the observer
  */
 export function startDynamicPageScanner(
-  onNewNodes: (nodes: Text[]) => void,
-  debounceMs = 400
+  onScan: (event: DynamicScanEvent) => void,
+  options: DynamicScannerOptions = {}
 ): () => void {
   if (observer) return () => {};
+
+  const debounceMs = options.debounceMs ?? 400;
+  const throttleMs = options.throttleMs ?? 500;
+  lastDispatchTime = Date.now() - throttleMs;
+  resetPendingState();
+  processedNodes = new WeakSet<Text>();
+  currentPopstateHandler = () => queueFullScan(onScan, debounceMs, throttleMs);
 
   observer = new MutationObserver((mutations) => {
     const newNodes: Text[] = [];
@@ -123,7 +296,9 @@ export function startDynamicPageScanner(
         const nodes =
           added instanceof Text
             ? added.textContent?.trim() && isNodeVisible(added)
-              ? [added]
+              ? isHighlightedTextNode(added)
+                ? []
+                : [added]
               : []
             : added instanceof Element
               ? collectVisibleTextNodes(added)
@@ -132,20 +307,22 @@ export function startDynamicPageScanner(
       }
     }
 
-    if (newNodes.length > 0) {
-      if (scanTimeout) clearTimeout(scanTimeout);
-      scanTimeout = setTimeout(() => onNewNodes(newNodes), debounceMs);
-    }
+    queueIncrementalNodes(newNodes, onScan, debounceMs, throttleMs);
   });
 
   observer.observe(document.body, {
     childList: true,
     subtree: true,
   });
+  patchHistory(onScan, debounceMs, throttleMs);
 
   return () => {
     observer?.disconnect();
     observer = null;
-    if (scanTimeout) clearTimeout(scanTimeout);
+    if (scheduleTimeout) clearTimeout(scheduleTimeout);
+    scheduleTimeout = null;
+    currentPopstateHandler = null;
+    unpatchHistory();
+    resetPendingState();
   };
 }


### PR DESCRIPTION
Fixes #10

## Summary
- upgrade `startDynamicPageScanner()` to emit throttled dynamic scan events for incremental node batches and SPA-triggered full re-scans
- deduplicate rapid mutation batches, skip already-highlighted text nodes, and intercept `pushState` / `replaceState` / `popstate` to rescan SPA pages safely
- update the content script to consume incremental vs full scan events and expand scanner tests to cover debounce, dedup, highlight skipping, throttling, and SPA navigation

## Test Plan
- [x] `npm test -- src/content/text-scanner.test.ts src/content/detector.test.ts src/content/highlighter.test.ts src/content/highlight-detections.integration.test.ts`
- [x] `npm run build`