### PR TITLE
feat: wire content risk messaging pipeline

### DIFF
--- a/src/background/index.test.ts
+++ b/src/background/index.test.ts
@@ -108,4 +108,53 @@ describe("background handleMessage", () => {
       },
     });
   });
+
+  it("returns profile and risk assessment for GET_RISK_ASSESSMENT token requests", async () => {
+    const profile: TokenProfile = {
+      id: "ethereum",
+      coingeckoId: "ethereum",
+      name: "Ethereum",
+      symbol: "ETH",
+      chains: ["ethereum"],
+      price: 1000,
+      priceChange24h: 0,
+      ath: 4000,
+      supply: {
+        type: "inflationary",
+        circulatingSupply: 100,
+        totalSupply: 100,
+        circulatingPercent: 100,
+        marketCap: 1000000,
+        fdv: 1000000,
+        fdvToMcapRatio: 1,
+        hasBurnMechanism: false,
+      },
+      lastUpdated: Date.now(),
+    };
+
+    fetchTokenById.mockResolvedValue(profile);
+    fetchFundamentals.mockResolvedValue(null);
+    fetchPrices.mockResolvedValue({});
+    getRiskAssessment.mockResolvedValue({
+      riskLevel: "low",
+      score: 10,
+      verdict: "No major concerns detected",
+      insights: [],
+      providers: ["Internal Heuristics"],
+    });
+
+    const { handleMessage } = await import("./index");
+    const result = await handleMessage({
+      type: "GET_RISK_ASSESSMENT",
+      payload: { id: "ethereum" },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        profile: expect.objectContaining({ id: "ethereum" }),
+        risk: expect.objectContaining({ riskLevel: "low" }),
+      },
+    });
+  });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -57,6 +57,15 @@ function isSearchTokenPayload(
   return isRecord(payload) && typeof payload.query === "string";
 }
 
+/**
+ * Narrows risk-assessment payloads received over the extension message bus.
+ */
+function isRiskAssessmentPayload(
+  payload: unknown,
+): payload is { id: string } | { address: string; chain: Chain } {
+  return isResolveTokenPayload(payload) || isResolveAddressPayload(payload);
+}
+
 // ---------- Message handler ----------
 
 chrome.runtime.onMessage.addListener(
@@ -89,6 +98,11 @@ export async function handleMessage(message: Message): Promise<MessageResponse> 
       return isSearchTokenPayload(message.payload)
         ? searchToken(message.payload)
         : { success: false, error: "Invalid SEARCH_TOKEN payload" };
+
+    case "GET_RISK_ASSESSMENT":
+      return isRiskAssessmentPayload(message.payload)
+        ? getRiskAssessment(message.payload)
+        : { success: false, error: "Invalid GET_RISK_ASSESSMENT payload" };
 
     case "GET_SETTINGS":
     case "UPDATE_SETTINGS":
@@ -168,6 +182,15 @@ async function searchToken(payload: {
     return { success: true, data: profile };
   }
   return { success: false, error: "Token not found" };
+}
+
+async function getRiskAssessment(payload: {
+  id: string;
+} | {
+  address: string;
+  chain: Chain;
+}): Promise<MessageResponse<{ profile: TokenProfile; risk: RiskAssessment }>> {
+  return "id" in payload ? resolveToken(payload) : resolveAddress(payload);
 }
 
 /**

--- a/src/content/highlight-detections.ts
+++ b/src/content/highlight-detections.ts
@@ -28,6 +28,7 @@ export function highlightDetectedTerms(nodes: Text[]): number {
       highlightRanges(
         node,
         matches.map((match) => ({
+          detection: match.detection,
           end: match.end,
           start: match.start,
           text: match.detection.text,

--- a/src/content/highlighter.test.ts
+++ b/src/content/highlighter.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { highlightNodes, removeAllHighlights } from "./highlighter";
+import { highlightNodes, highlightRanges, removeAllHighlights } from "./highlighter";
 
 describe("highlightNodes", () => {
   beforeEach(() => {
@@ -84,5 +84,42 @@ describe("removeAllHighlights", () => {
     removeAllHighlights();
     expect(document.body.querySelectorAll(".crypto-xray-highlight")).toHaveLength(0);
     expect(document.body.textContent).toBe("$SOL is great");
+  });
+});
+
+describe("highlightRanges", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("stores detector metadata on highlight spans", () => {
+    const text = document.createTextNode("Track Ethereum.");
+    document.body.appendChild(text);
+
+    const highlighted = highlightRanges(text, [
+      {
+        start: 6,
+        end: 14,
+        text: "Ethereum",
+        detection: {
+          text: "Ethereum",
+          type: "name",
+          ticker: "ETH",
+          coingeckoId: "ethereum",
+          confidence: 0.92,
+        },
+      },
+    ]);
+
+    expect(highlighted).toBe(true);
+    const span = document.querySelector(".crypto-xray-highlight") as HTMLSpanElement;
+    expect(span.dataset.entityType).toBe("name");
+    expect(span.dataset.coingeckoId).toBe("ethereum");
+    expect(span.dataset.ticker).toBe("ETH");
+    expect(span.dataset.confidence).toBe("0.92");
   });
 });

--- a/src/content/highlighter.ts
+++ b/src/content/highlighter.ts
@@ -1,3 +1,5 @@
+import type { DetectedToken } from "@/shared/types";
+
 /**
  * DOM highlighter for crypto-related terms.
  * Wraps detected tokens in styled spans with inline styles (CSP-safe).
@@ -21,6 +23,7 @@ export interface HighlightRange {
   end: number;
   start: number;
   text: string;
+  detection?: DetectedToken;
 }
 
 /**
@@ -28,11 +31,24 @@ export interface HighlightRange {
  * @param text - The text content to highlight
  * @returns A styled span element
  */
-function createHighlightSpan(text: string): HTMLSpanElement {
+function createHighlightSpan(text: string, detection?: DetectedToken): HTMLSpanElement {
   const span = document.createElement("span");
   span.className = HIGHLIGHT_CLASS;
   span.textContent = text;
   span.dataset.token = text.toLowerCase();
+  if (detection) {
+    span.dataset.entityType = detection.type;
+    span.dataset.confidence = String(detection.confidence);
+    if (detection.coingeckoId) {
+      span.dataset.coingeckoId = detection.coingeckoId;
+    }
+    if (detection.ticker) {
+      span.dataset.ticker = detection.ticker;
+    }
+    if (detection.chain) {
+      span.dataset.chain = detection.chain;
+    }
+  }
   Object.assign(span.style, HIGHLIGHT_STYLE);
   return span;
 }
@@ -144,7 +160,7 @@ export function highlightRanges(node: Text, ranges: HighlightRange[]): boolean {
       fragment.appendChild(document.createTextNode(text.slice(lastIndex, range.start)));
     }
 
-    fragment.appendChild(createHighlightSpan(range.text));
+    fragment.appendChild(createHighlightSpan(range.text, range.detection));
     lastIndex = range.end;
   }
 

--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMessage = vi.fn();
+const getVisibleTextNodes = vi.fn(() => []);
+const startDynamicPageScanner = vi.fn();
+const highlightDetectedTerms = vi.fn(() => 0);
+
+vi.mock("./messaging", () => ({
+  sendMessage,
+}));
+
+vi.mock("./text-scanner", () => ({
+  getVisibleTextNodes,
+  startDynamicPageScanner,
+}));
+
+vi.mock("./highlight-detections", () => ({
+  highlightDetectedTerms,
+}));
+
+describe("content interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("builds a GET_RISK_ASSESSMENT request for dictionary-backed highlights", async () => {
+    const { buildRiskAssessmentMessage } = await import("./index");
+
+    const span = document.createElement("span");
+    span.dataset.coingeckoId = "ethereum";
+    span.dataset.entityType = "name";
+
+    expect(buildRiskAssessmentMessage(span)).toEqual({
+      type: "GET_RISK_ASSESSMENT",
+      payload: { id: "ethereum" },
+    });
+  });
+
+  it("builds a GET_RISK_ASSESSMENT request for address highlights", async () => {
+    const { buildRiskAssessmentMessage } = await import("./index");
+
+    const span = document.createElement("span");
+    span.textContent = "0xabc";
+    span.dataset.entityType = "address";
+    span.dataset.chain = "ethereum";
+
+    expect(buildRiskAssessmentMessage(span)).toEqual({
+      type: "GET_RISK_ASSESSMENT",
+      payload: { address: "0xabc", chain: "ethereum" },
+    });
+  });
+
+  it("sends a background message when a highlighted entity is hovered", async () => {
+    const { initializeContentScript } = await import("./index");
+
+    const span = document.createElement("span");
+    span.className = "crypto-xray-highlight";
+    span.textContent = "Ethereum";
+    span.dataset.coingeckoId = "ethereum";
+    span.dataset.entityType = "name";
+    document.body.appendChild(span);
+
+    initializeContentScript();
+    span.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "GET_RISK_ASSESSMENT",
+      payload: { id: "ethereum" },
+    });
+  });
+});

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,7 +1,57 @@
 import { highlightDetectedTerms } from "./highlight-detections";
+import { sendMessage } from "./messaging";
 import { getVisibleTextNodes, startDynamicPageScanner } from "./text-scanner";
+import type { Chain, Message } from "@/shared/types";
 
-try {
+const HIGHLIGHT_SELECTOR = ".crypto-xray-highlight";
+
+/**
+ * Builds the generic background request for a highlighted entity using only
+ * metadata stored on the span.
+ */
+export function buildRiskAssessmentMessage(element: HTMLElement): Message | null {
+  if (element.dataset.coingeckoId) {
+    return {
+      type: "GET_RISK_ASSESSMENT",
+      payload: { id: element.dataset.coingeckoId },
+    };
+  }
+
+  if (
+    element.dataset.entityType === "address" &&
+    element.dataset.chain &&
+    element.textContent
+  ) {
+    return {
+      type: "GET_RISK_ASSESSMENT",
+      payload: {
+        address: element.textContent,
+        chain: element.dataset.chain as Chain,
+      },
+    };
+  }
+
+  return null;
+}
+
+async function requestRiskAssessment(element: HTMLElement): Promise<void> {
+  const message = buildRiskAssessmentMessage(element);
+  if (!message) {
+    return;
+  }
+
+  try {
+    await sendMessage(message);
+  } catch (error) {
+    console.error("[Crypto X-Ray] Risk assessment request failed:", error);
+  }
+}
+
+/**
+ * Boots the content-script scan pipeline and wires highlight interactions to
+ * the background messaging client.
+ */
+export function initializeContentScript(): void {
   console.log("[Crypto X-Ray] Content script loaded");
 
   function scan(): void {
@@ -22,6 +72,30 @@ try {
 
   scan();
 
+  document.addEventListener("mouseenter", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const highlight = target.closest(HIGHLIGHT_SELECTOR);
+    if (highlight instanceof HTMLElement) {
+      void requestRiskAssessment(highlight);
+    }
+  }, true);
+
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    const highlight = target.closest(HIGHLIGHT_SELECTOR);
+    if (highlight instanceof HTMLElement) {
+      void requestRiskAssessment(highlight);
+    }
+  });
+
   startDynamicPageScanner((event) => {
     if (event.type === "full") {
       console.log("[Crypto X-Ray] SPA navigation detected, running full re-scan");
@@ -35,6 +109,10 @@ try {
   });
 
   console.log("[Crypto X-Ray] Dynamic page scanner started");
+}
+
+try {
+  initializeContentScript();
 } catch (err) {
   console.error("[Crypto X-Ray] Fatal error:", err);
 }

--- a/src/content/messaging.test.ts
+++ b/src/content/messaging.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendMessage } from "./messaging";
+import type { Message } from "@/shared/types";
+
+const sendMessageMock = vi.fn();
+
+vi.stubGlobal("chrome", {
+  runtime: {
+    sendMessage: sendMessageMock,
+  },
+});
+
+describe("sendMessage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reuses one in-flight request for identical messages", async () => {
+    let resolveResponse: ((value: { success: true; data: { ok: boolean } }) => void) | undefined;
+    sendMessageMock.mockImplementation(
+      (_message: Message, callback: (response: { success: true; data: { ok: boolean } }) => void) => {
+        resolveResponse = callback;
+      },
+    );
+
+    const message: Message = {
+      type: "GET_RISK_ASSESSMENT",
+      payload: { id: "ethereum" },
+    };
+
+    const first = sendMessage<{ ok: boolean }>(message);
+    const second = sendMessage<{ ok: boolean }>(message);
+
+    expect(first).toBe(second);
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    resolveResponse?.({ success: true, data: { ok: true } });
+
+    await expect(first).resolves.toEqual({ success: true, data: { ok: true } });
+    await expect(second).resolves.toEqual({ success: true, data: { ok: true } });
+  });
+
+  it("rejects when the background response times out", async () => {
+    sendMessageMock.mockImplementation(() => undefined);
+
+    const promise = sendMessage({
+      type: "GET_RISK_ASSESSMENT",
+      payload: { address: "0xabc", chain: "ethereum" },
+    });
+    const rejection = expect(promise).rejects.toThrow("Background request timed out");
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await rejection;
+  });
+});

--- a/src/content/messaging.ts
+++ b/src/content/messaging.ts
@@ -1,0 +1,48 @@
+import type { Message, MessageResponse } from "@/shared/types";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const inflightRequests = new Map<string, Promise<MessageResponse<unknown>>>();
+
+/**
+ * Sends a typed message to the background worker with request deduplication and
+ * timeout handling so hover-driven lookups do not fan out duplicate requests.
+ */
+export function sendMessage<T>(message: Message): Promise<MessageResponse<T>> {
+  const dedupKey = getDedupKey(message);
+  const existing = inflightRequests.get(dedupKey);
+  if (existing) {
+    return existing as Promise<MessageResponse<T>>;
+  }
+
+  const request = new Promise<MessageResponse<T>>((resolve, reject) => {
+    const timeoutId = globalThis.setTimeout(() => {
+      inflightRequests.delete(dedupKey);
+      reject(new Error("Background request timed out"));
+    }, REQUEST_TIMEOUT_MS);
+
+    chrome.runtime.sendMessage(message, (response: MessageResponse<T>) => {
+      globalThis.clearTimeout(timeoutId);
+      inflightRequests.delete(dedupKey);
+      resolve(response);
+    });
+  });
+
+  inflightRequests.set(dedupKey, request as Promise<MessageResponse<unknown>>);
+  return request;
+}
+
+function getDedupKey(message: Message): string {
+  const payload =
+    typeof message.payload === "object" && message.payload !== null
+      ? (message.payload as Record<string, unknown>)
+      : {};
+
+  const id =
+    typeof payload.id === "string"
+      ? payload.id
+      : typeof payload.address === "string"
+        ? payload.address
+        : JSON.stringify(payload);
+
+  return `${message.type}:${id}`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -395,6 +395,7 @@ export const CACHE_TTL = {
 export type MessageType =
   | "RESOLVE_TOKEN"
   | "RESOLVE_ADDRESS"
+  | "GET_RISK_ASSESSMENT"
   | "GET_SETTINGS"
   | "UPDATE_SETTINGS"
   | "SEARCH_TOKEN";


### PR DESCRIPTION
## Summary
- add a content-side messaging client with request deduplication and timeout handling
- attach detector metadata to highlight spans and wire content-script hover/click interactions to GET_RISK_ASSESSMENT
- add background support for GET_RISK_ASSESSMENT as the generic risk lookup entry point

## Testing
- npm test -- src/content/index.test.ts src/content/messaging.test.ts src/background/index.test.ts src/content/highlighter.test.ts
- npm test

Closes #5